### PR TITLE
Signing failure resistance

### DIFF
--- a/lib/node-diaspora.js
+++ b/lib/node-diaspora.js
@@ -5,14 +5,14 @@ function Diaspora(options){
 
 	if (!options || !options.user || !options.password || !options.pod)
 		throw new Error("User, password and pod are necessary.");
-	
+
 	this.username   = options.user;
 	this.password   = options.password;
 	this.pod        = options.pod;
-	this.share_url = '/status_messages';
+	this.share_url  = '/status_messages';
 	this.login_url  = '/users/sign_in';
-	this.j       = request.jar();
-	this.request = request.defaults({ jar: this.j });
+	this.j          = request.jar();
+	this.request    = request.defaults({ jar: this.j });
 
 }
 
@@ -22,11 +22,12 @@ Diaspora.prototype.connect = function(callback){
 
 	this.getFormData(function(cookie, token){
 
-		self.login(token, function(res){
+		self.login(token, function(res, message){
 
-			if(res=="200 OK") throw new Error("User or password incorrect.");
+			if(!message) message = "User or password incorrect.";
+			if(res=="200 OK") callback(new Error(message), message);
 			if(res=="302 Found") callback(null, "Login has been successful.");
-				
+
 		});
 
 	});
@@ -47,8 +48,13 @@ Diaspora.prototype.login = function(token, callback){
 		}
 	}, function(err, res) {
 
+		// Message example:
+		//<div id="flash_alert"><div class="message">Invalid email or password.</div></div>
+		var message = res.body.match('id="flash_alert"[^>]*>(.*?)</div>');
+		if (message) message = message[1].replace(/<[^>]*>/, '');
+		else message = null;
 		if(err) throw new Error(err.code);
-		callback(res.headers.status);
+		callback(res.headers.status, message);
 
 	});
 
@@ -61,7 +67,10 @@ Diaspora.prototype.getFormData = function(callback){
 	this.request.get(this.pod+this.login_url, function(err, res){
 
 		if(err) throw new Error(err.code);
-		callback(res.headers['set-cookie'][0].split(";")[0], res.body.match('<input name="authenticity_token" type="hidden" value="(.*)" />')[1]);
+		callback(
+			res.headers['set-cookie'][0].split(";")[0],
+			res.body.match('<input[^>]* name="authenticity_token"[^>]* value="(.*)"')[1]
+		);
 
 	});
 


### PR DESCRIPTION
- Make it to find `authenticity_token` input with a different structure
- Do not crash on login fail, uses the standard async approach, returning error.
